### PR TITLE
feat: make "numeral" a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@
 ## In the browser
 
 ```html
-<script src="https://unpkg.com/vue-numerals/dist/vue-numerals.min.js" />
+<!-- Import Numeral.js (http://numeraljs.com/#use-it) -->
+<script src="//cdnjs.cloudflare.com/ajax/libs/numeral.js/2.0.0/numeral.min.js"></script>
+<!-- Then import vue-numerals -->
+<script src="https://unpkg.com/vue-numerals/dist/vue-numerals.min.js"></script>
 ```
 
 ## With Node.js
 
 ```bash
-$ yarn add vue-numerals
+$ yarn add vue-numerals 'numeral@>=2'
 ```
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
     "jest": "^23.6.0",
+    "numeral": "^2.0.6",
     "precise-commits": "^1.0.2",
     "prettier": "^1.13.5",
     "semantic-release": "^15.12.0",
@@ -44,9 +45,7 @@
     "webpack-cli": "^3.0.3"
   },
   "peerDependencies": {
-    "vue": "^2.5.16"
-  },
-  "dependencies": {
-    "numeral": "^2.0.6"
+    "numeral": ">=2",
+    "vue": ">=2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5868,6 +5868,7 @@ number-is-nan@^1.0.0:
 numeral@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
+  integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
 
 nwsapi@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
BREAKING CHANGE: You should manually install "numeral" package. Please run `npm install 'numeral@>=2'` or `yarn add 'numeral@>=2'`.