### PR TITLE
fix(default-locale): switch default locale from `fr` to `en`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ yarn add vue-numerals 'numeral@>=2'
 import Vue from 'vue';
 import VueNumerals from 'vue-numerals';
 
-Vue.use(VueNumerals);
+Vue.use(VueNumerals); // default locale is 'en'
 
 // with options
 Vue.use(VueNumerals, {
@@ -47,10 +47,10 @@ Inside your component:
 ```vue
 <template>
   <div>
-    <!-- With french locale, it will display: `12 345` -->
+    <!-- Will display: `12,345` -->
     <p>{{ count | numeralFormat }}</p>
     
-    <!-- With french locale, it will display: `12 345 €` --> 
+    <!-- Will display: `12,345 $` --> 
     <p>{{ count | numeralFormat('0,0[.]00 $') }}</p>
   </div>
 </template>

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ import 'numeral/locales';
  * @param {VueConstructor} Vue
  * @param {string?} locale
  */
-export default function install(Vue, { locale } = { locale: null }) {
-  numeral.locale(locale || 'fr');
+export default function install(Vue, { locale = 'en' } = {}) {
+  numeral.locale(locale);
 
   Vue.filter('numeralFormat', (value, format = '0,0') => numeral(value).format(format));
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,8 +12,24 @@ describe('filter', () => {
     localVue = createLocalVue();
   });
 
-  test('format with default locale (fr) and default format', () => {
+  test('format with default locale (en) and default format', () => {
     localVue.use(VueNumerals);
+
+    wrapper = mount({ template: '<p>{{ 12345 | numeralFormat }}</p>' }, { localVue });
+
+    expect(wrapper.html()).toBe('<p>12,345</p>');
+  });
+
+  test('format with default locale (en) and custom format', () => {
+    localVue.use(VueNumerals);
+
+    wrapper = mount({ template: '<p>{{ 12345 | numeralFormat("0o") }}</p>' }, { localVue });
+
+    expect(wrapper.html()).toBe('<p>12345th</p>');
+  });
+
+  test('format with custom locale (fr) and default format', () => {
+    localVue.use(VueNumerals, { locale: 'fr' });
 
     wrapper = mount({ template: '<p>{{ 12345 | numeralFormat }}</p>' }, { localVue });
 
@@ -21,19 +37,11 @@ describe('filter', () => {
   });
 
   test('format with default locale (fr) and custom format', () => {
-    localVue.use(VueNumerals);
+    localVue.use(VueNumerals, { locale: 'fr' });
 
     wrapper = mount({ template: '<p>{{ 12345 | numeralFormat("0o") }}</p>' }, { localVue });
 
     expect(wrapper.html()).toBe('<p>12345e</p>');
-  });
-
-  test('format with custom locale (en) and default format', () => {
-    localVue.use(VueNumerals, { locale: 'en' });
-
-    wrapper = mount({ template: '<p>{{ 12345 | numeralFormat }}</p>' }, { localVue });
-
-    expect(wrapper.html()).toBe('<p>12,345</p>');
   });
 
   test('format with custom locale (ru) and custom format', () => {


### PR DESCRIPTION
BREAKING CHANGE: The default locale has been changed from `fr` to `en`, as Numeral.js does. If you want to keep using the locale `fr`, use `Vue.use(VueMoment, { locale: 'fr' })`.